### PR TITLE
default port error in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,4 +28,4 @@ services:
       - CLASH_TOKEN=
     restart: always
     ports:
-      - 2122:2122
+      - 2112:2112


### PR DESCRIPTION
默认端口2112，但这里写成2122，导致无法直接使用